### PR TITLE
Make climb use encoders

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -35,6 +35,8 @@ public class Constants {
     public static final int CAMERA_WIDTH = 640;
     public static final int CAMERA_BIT_CORRECTION_AMOUNT = 0;
     /**This is the amount of frames in a row that an april tag needs in frame to be to be considered confidently an april tag */
+    public static final int APRIL_TAG_CONFIDENCE_FRAMES = 3;
+    public static final double APRIL_TAG_ROTATION_ZONE = 5;
 
     /*PID GAINS *///0.00001, 100
     public static final Gains ROTATION_GAINS = new Gains(0.011, 0.0001, 0.000935, 0, 0, 0.3);
@@ -55,8 +57,6 @@ public class Constants {
     public static final int TIMEOUT_MS = 30;
     public static final double ENCODER_ROTATION = 4096.0;
     /* ROTATION PID CONSTANTS */
-    public static final int APRIL_TAG_CONFIDENCE_FRAMES = 3;
-    public static final double APRIL_TAG_ROTATION_ZONE = 5;
 
     public static final double ROTATION_ERROR_DEGREES = 5.;
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -18,10 +18,8 @@ public class Constants {
     public static final double REV_TIME = 1.0;
 
     /*CLIMB CONFIG */
-    /**the time we give the arms to extend in seconds */
-    public static final double ARM_EXTENSION_TIME = 3;
-    /**the time we give the arms to retract in seconds */
-    public static final double ARM_RETRACTION_TIME = 3;
+    public static final double CLIMB_EXTENDED_ENCODER_POSITION = 5;
+    public static final double CLIMB_RETRACTED_ENCODER_POSITION = 0.5;
     /**the % of max power we give to the arm motors while extending */
     public static final double ARM_EXTENSION_SPEED = .25;
     /**the % of max power we give to the arm motors while retracting */
@@ -37,8 +35,6 @@ public class Constants {
     public static final int CAMERA_WIDTH = 640;
     public static final int CAMERA_BIT_CORRECTION_AMOUNT = 0;
     /**This is the amount of frames in a row that an april tag needs in frame to be to be considered confidently an april tag */
-    public static final int APRIL_TAG_CONFIDENCE_FRAMES = 3;
-    public static final double APRIL_TAG_ROTATION_ZONE = 5;
 
     /*PID GAINS *///0.00001, 100
     public static final Gains ROTATION_GAINS = new Gains(0.011, 0.0001, 0.000935, 0, 0, 0.3);
@@ -58,7 +54,9 @@ public class Constants {
     /** amount of time in ms to wait for confirmation */
     public static final int TIMEOUT_MS = 30;
     public static final double ENCODER_ROTATION = 4096.0;
-
     /* ROTATION PID CONSTANTS */
+    public static final int APRIL_TAG_CONFIDENCE_FRAMES = 3;
+    public static final double APRIL_TAG_ROTATION_ZONE = 5;
+
     public static final double ROTATION_ERROR_DEGREES = 5.;
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -21,9 +21,9 @@ public class Constants {
     public static final double CLIMB_EXTENDED_ENCODER_POSITION = 5;
     public static final double CLIMB_RETRACTED_ENCODER_POSITION = 0.5;
     /**the % of max power we give to the arm motors while extending */
-    public static final double ARM_EXTENSION_SPEED = .25;
+    public static final double CLIMB_EXTENSION_SPEED = .25;
     /**the % of max power we give to the arm motors while retracting */
-    public static final double ARM_RETRACTION_SPEED = .25;
+    public static final double CLIMB_RETRACTION_SPEED = -.25;
     /*DRIVE TRAIN CONFIG */
     public static final double CONTROLLER_DEADZONE = 0.06;
 

--- a/src/main/java/frc/robot/InputtedCoDriverControls.java
+++ b/src/main/java/frc/robot/InputtedCoDriverControls.java
@@ -14,6 +14,8 @@ public class InputtedCoDriverControls {
     }
 
     public static void onEveryFrame() {
+        Robot.motors.getLeftClimb().stopMotor();
+        Robot.motors.getRightClimb().stopMotor();
         if (controller.getAButton()) {
             Robot.motors.getFeeder().set(30);
         } else {
@@ -24,19 +26,25 @@ public class InputtedCoDriverControls {
         }
         doShooterIntake();
         if (controller.getStartButton()) {
-            extendArms();
+            //extendArms();
+            Robot.motors.getLeftClimb().set(Constants.CLIMB_EXTENSION_SPEED);
+            Robot.motors.getRightClimb().set(Constants.CLIMB_EXTENSION_SPEED);
         }
         if (controller.getBackButton()) {
-            retractArms();
+            //retractArms();
+            Robot.motors.getLeftClimb().set(Constants.CLIMB_RETRACTION_SPEED);
+            Robot.motors.getRightClimb().set(Constants.CLIMB_RETRACTION_SPEED);
         }
     }
 
     private static void extendArms() {
         Robot.getTeleopActionRunner().addActionToRun(new ExtendArms());
+        Robot.getTeleopActionRunner().removeActionsOfType(RetractArms.class);
     }
 
     private static void retractArms() {
         Robot.getTeleopActionRunner().addActionToRun(new RetractArms());
+        Robot.getTeleopActionRunner().removeActionsOfType(ExtendArms.class);
     }
 
     private static void doShooterIntake() {

--- a/src/main/java/frc/robot/auton/ExtendArms.java
+++ b/src/main/java/frc/robot/auton/ExtendArms.java
@@ -6,11 +6,9 @@ import frc.robot.Robot;
 
 public class ExtendArms extends AutonAction {
 
-    private double extensionTime;
-
     @Override
     public boolean isDone() {
-        if (Timer.getFPGATimestamp() >= extensionTime) {
+        if (Robot.motors.getLeftClimb().getEncoderPosition() > Constants.CLIMB_EXTENDED_ENCODER_POSITION) {
             Robot.motors.getLeftClimb().set(0);
             Robot.motors.getRightClimb().set(0);
             return true;
@@ -22,6 +20,5 @@ public class ExtendArms extends AutonAction {
     public void initiate() {
         Robot.motors.getLeftClimb().set(Constants.ARM_EXTENSION_SPEED);
         Robot.motors.getRightClimb().set(Constants.ARM_EXTENSION_SPEED);
-        extensionTime = Timer.getFPGATimestamp() + Constants.ARM_EXTENSION_TIME;
     }
 }

--- a/src/main/java/frc/robot/auton/ExtendArms.java
+++ b/src/main/java/frc/robot/auton/ExtendArms.java
@@ -18,7 +18,7 @@ public class ExtendArms extends AutonAction {
 
     @Override
     public void initiate() {
-        Robot.motors.getLeftClimb().set(Constants.ARM_EXTENSION_SPEED);
-        Robot.motors.getRightClimb().set(Constants.ARM_EXTENSION_SPEED);
+        Robot.motors.getLeftClimb().set(Constants.CLIMB_EXTENSION_SPEED);
+        Robot.motors.getRightClimb().set(Constants.CLIMB_EXTENSION_SPEED);
     }
 }

--- a/src/main/java/frc/robot/auton/ParallelActionRunner.java
+++ b/src/main/java/frc/robot/auton/ParallelActionRunner.java
@@ -1,6 +1,7 @@
 package frc.robot.auton;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 public class ParallelActionRunner {
@@ -13,11 +14,24 @@ public class ParallelActionRunner {
     }
 
     public void onEveryFrame() {
-        for (int i = 0; i < actions.size(); i++) {
-            AutonAction action = actions.get(i);
+        Iterator<AutonAction> it = actions.iterator();
+        while (it.hasNext()) {
+            AutonAction action = it.next();
             if (action.isDone()) {
-                actions.remove(i);
-                i--;
+                actions.remove(action);
+            }
+        }
+    }
+
+    // This method is important if you have code that could add two of the same action with opposite goals.
+    // That would mean they would fight each other and never finish, which is bad news bears if you ask me.
+    public void removeActionsOfType(AutonAction action) {
+        Class<?> clazz = action.getClass();
+        Iterator<AutonAction> it = actions.iterator();
+        while (it.hasNext()) {
+            AutonAction auction = it.next();
+            if (auction.getClass().equals(clazz)) {
+                actions.remove(auction);
             }
         }
     }

--- a/src/main/java/frc/robot/auton/ParallelActionRunner.java
+++ b/src/main/java/frc/robot/auton/ParallelActionRunner.java
@@ -25,8 +25,7 @@ public class ParallelActionRunner {
 
     // This method is important if you have code that could add two of the same action with opposite goals.
     // That would mean they would fight each other and never finish, which is bad news bears if you ask me.
-    public void removeActionsOfType(AutonAction action) {
-        Class<?> clazz = action.getClass();
+    public void removeActionsOfType(Class<?> clazz) {
         Iterator<AutonAction> it = actions.iterator();
         while (it.hasNext()) {
             AutonAction auction = it.next();
@@ -34,5 +33,9 @@ public class ParallelActionRunner {
                 actions.remove(auction);
             }
         }
+    }
+
+    public void removeActionsOfType(AutonAction action) {
+        removeActionsOfType(action.getClass());
     }
 }

--- a/src/main/java/frc/robot/auton/RetractArms.java
+++ b/src/main/java/frc/robot/auton/RetractArms.java
@@ -6,11 +6,9 @@ import frc.robot.Robot;
 
 public class RetractArms extends AutonAction {
 
-    private double extensionTime;
-
     @Override
     public boolean isDone() {
-        if (Timer.getFPGATimestamp() >= extensionTime) {
+        if (Robot.motors.getLeftClimb().getEncoderPosition() < Constants.CLIMB_RETRACTED_ENCODER_POSITION) {
             Robot.motors.getLeftClimb().set(0);
             Robot.motors.getRightClimb().set(0);
             return true;
@@ -22,6 +20,5 @@ public class RetractArms extends AutonAction {
     public void initiate() {
         Robot.motors.getLeftClimb().set(Constants.ARM_RETRACTION_SPEED);
         Robot.motors.getRightClimb().set(Constants.ARM_RETRACTION_SPEED);
-        extensionTime = Timer.getFPGATimestamp() + Constants.ARM_RETRACTION_TIME;
     }
 }

--- a/src/main/java/frc/robot/auton/RetractArms.java
+++ b/src/main/java/frc/robot/auton/RetractArms.java
@@ -18,7 +18,7 @@ public class RetractArms extends AutonAction {
 
     @Override
     public void initiate() {
-        Robot.motors.getLeftClimb().set(Constants.ARM_RETRACTION_SPEED);
-        Robot.motors.getRightClimb().set(Constants.ARM_RETRACTION_SPEED);
+        Robot.motors.getLeftClimb().set(Constants.CLIMB_RETRACTION_SPEED);
+        Robot.motors.getRightClimb().set(Constants.CLIMB_RETRACTION_SPEED);
     }
 }


### PR DESCRIPTION
# Description

We made the arms use encoder positions because using time is unreliable and inconvenient

# Checklist before marking this PR as ready for review

-   [x] All the PR checks are passing (you see the green checkmark)
-   [x] I have written comments on the PR where reviewers may have questions

## Once you have the PR ready for review, request reviewers from the upper-right of the screen with the cog on the reviewers section.
